### PR TITLE
feat: add diff mode to Brakeman CI action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'Run brakeman with reviewdog'
-description: '🐶 Run brakeman with reviewdog on pull requests to improve code review experience.'
-author: 'mgrachev (reviewdog)'
+description: '🐶 Run brakeman in full or diff mode. Use reviewdog for annotations, or fail on new issues only.'
+author: 'mgrachev (reviewdog), extended by Labguru'
+
 inputs:
   github_token:
     description: 'GITHUB_TOKEN'
@@ -51,9 +52,28 @@ inputs:
   use_bundler:
     description: "Run Brakeman with bundle exec. Default: `false`"
     default: 'false'
+  mode:
+    description: |
+      Run mode:
+      - `full` (default): Run Brakeman and report all findings using reviewdog annotations on the pull request.
+      - `diff`: Run Brakeman on both the base and PR commits, and fail only if new warnings are introduced in changed Ruby files.
+    default: 'full'
+
 runs:
   using: 'composite'
   steps:
+    - name: Extract PR metadata
+      shell: sh
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "MERGE_BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+        echo "MERGE_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+
+        changed_files="$(gh pr view ${{ github.event.pull_request.number }} --json files -q '.files[].path')"
+        changed_ruby_files="$(echo "$changed_files" | grep -v '^vendor/' | grep '\.rb$' || true)"
+        echo "CHANGED_RUBY_FILES=$(echo "$changed_ruby_files" | tr '\n' ':' )" >> $GITHUB_ENV
+
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: sh
       env:
@@ -71,6 +91,11 @@ runs:
         INPUT_WORKDIR: ${{ inputs.workdir }}
         INPUT_SKIP_INSTALL: ${{ inputs.skip_install }}
         INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}
+        INPUT_MODE: ${{ inputs.mode }}
+        MERGE_BASE_REF: ${{ env.MERGE_BASE_REF }}
+        MERGE_BASE_SHA: ${{ env.MERGE_BASE_SHA }}
+        CHANGED_RUBY_FILES: ${{ env.CHANGED_RUBY_FILES }}
+
 branding:
   icon: 'check-circle'
   color: 'red'

--- a/run_diff.rb
+++ b/run_diff.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+MERGE_BASE_REF, MERGE_BASE_SHA, CHANGED_FILES_COLON = ARGV
+CHANGED_FILES = CHANGED_FILES_COLON.split(":").reject(&:empty?)
+BUNDLE_EXEC = ENV['BUNDLE_EXEC'] || ''
+BRAKEMAN_FLAGS = ENV['INPUT_BRAKEMAN_FLAGS'] || ''
+# HERE: The order of WARNING_COLUMNS must match the order of the brakeman report output
+WARNING_COLUMNS = ['Confidence', 'Category', 'Check', 'Message', 'Code', 'File', 'Line'].freeze
+
+def generate_report(report_type)
+  puts "📊 Generating #{report_type} report..."
+
+  full_report = "#{report_type}-full-report.out"
+  filtered_report = "#{report_type}-filtered-report.out"
+  brakeman_cmd = "#{BUNDLE_EXEC}brakeman --quiet --no-exit-on-warn --no-exit-on-error #{BRAKEMAN_FLAGS} --color -o #{full_report}"
+  # HERE: Do ** NOT ** try to grep columns followed by a colon ':', as it will not match the brakeman output
+  # HERE: because each column is colored in the output and the colon is not colored, so it won't be matched.
+  ##########################################################################
+  # Good:                                                                  #
+  # grep -E --color=never '(Colon1|Colon2)'                                #
+  ##########################################################################
+  # Bad:                                                                   #
+  # grep -E --color=never '(Colon1|Colon2):' <--- see the colon at the end #
+  ##########################################################################
+  report_cmd = [
+    "cat #{full_report}",
+    "grep -E --color=never -A1 -B5 '(#{CHANGED_FILES.join('|')})'",
+    "grep -E --color=never '(#{WARNING_COLUMNS.join('|')})'",
+    %Q{awk '
+      BEGIN { count=0 }
+      /#{WARNING_COLUMNS[-1]}/ { count++ }
+      { lines[NR]=$0 }
+      END {
+        printed=0
+        for (i=1; i<=NR; i++) {
+          print lines[i]
+          if (lines[i] ~ /#{WARNING_COLUMNS[-1]}/) {
+            printed++
+            if (printed < count) print "------"
+          }
+        }
+      }'}
+  ].join(' | ') + " > #{filtered_report}"
+
+  [brakeman_cmd, report_cmd].each do |cmd|
+    system(cmd, exception: true)
+  end
+
+  return filtered_report
+end
+
+puts "🔍 Base ref: #{MERGE_BASE_REF}"
+puts "🔍 Base SHA: #{MERGE_BASE_SHA}"
+puts "📝 Changed Ruby files:\n#{CHANGED_FILES.join("\n")}"
+
+puts "📥 Fetching base commit..."
+system("git fetch --depth 1 origin #{MERGE_BASE_SHA}")
+
+current_report = generate_report('current')
+
+# Checkout to the base commit
+system("git checkout --quiet #{MERGE_BASE_SHA}")
+
+base_report = generate_report('base')
+
+# Return to PR 'HEAD'
+system("git checkout --quiet -")
+
+current_count = File.read(current_report).scan(/#{WARNING_COLUMNS[0]}/).size
+base_count = File.read(base_report).scan(/#{WARNING_COLUMNS[0]}/).size
+
+puts "\n📊 Status Report:"
+puts "Current commit warning count: #{current_count}"
+puts "Base commit warning count: #{base_count}"
+
+if current_count > base_count
+  puts "\n📊 Current report generated:"
+  system("cat #{current_report}")
+  puts "\n❌ You introduced #{current_count - base_count} new Brakeman warnings in changed files."
+  exit 1
+end
+
+puts "\n✅ Brakeman warning count in changed files is not higher than on base commit."
+exit 0

--- a/run_full.sh
+++ b/run_full.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::group:: Running brakeman with reviewdog 🐶 ..."
+BRAKEMAN_REPORT_FILE="$(mktemp)"
+
+# shellcheck disable=SC2086
+${BUNDLE_EXEC}brakeman --quiet --format tabs --no-exit-on-warn --no-exit-on-error ${INPUT_BRAKEMAN_FLAGS} --output "$BRAKEMAN_REPORT_FILE"
+reviewdog < "$BRAKEMAN_REPORT_FILE" \
+  -f=brakeman \
+  -name="${INPUT_TOOL_NAME}" \
+  -reporter="${INPUT_REPORTER}" \
+  -filter-mode="${INPUT_FILTER_MODE}" \
+  -fail-level="${INPUT_FAIL_LEVEL}" \
+  -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
+  -level="${INPUT_LEVEL}" \
+  "${INPUT_REVIEWDOG_FLAGS}"
+
+exit_code=$?
+echo '::endgroup::'
+
+exit $exit_code

--- a/script.sh
+++ b/script.sh
@@ -1,71 +1,58 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-if [ -n "${GITHUB_WORKSPACE}" ]
-then
-    git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
-    git config --global --add safe.directory "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
-    cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
+if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+  git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit 1
+  git config --global --add safe.directory "$GITHUB_WORKSPACE/$INPUT_WORKDIR" || exit 1
+  cd "$GITHUB_WORKSPACE/$INPUT_WORKDIR" || exit 1
 fi
 
-export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+export REVIEWDOG_GITHUB_API_TOKEN="$INPUT_GITHUB_TOKEN"
 
 TEMP_PATH="$(mktemp -d)"
-PATH="${TEMP_PATH}:$PATH"
+export PATH="$TEMP_PATH:$PATH"
 
-echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
-echo '::endgroup::'
+# Install Brakeman
+if [[ "$INPUT_SKIP_INSTALL" == "false" ]]; then
+  echo "::group:: Installing Brakeman ..."
 
-if [ "${INPUT_SKIP_INSTALL}" = "false" ]; then
-  echo '::group:: Installing brakeman with extensions ... https://github.com/presidentbeef/brakeman'
-  # if 'gemfile' brakeman version selected
-  if [ "$INPUT_BRAKEMAN_VERSION" = "gemfile" ]; then
-    # if Gemfile.lock is here
-    if [ -f 'Gemfile.lock' ]; then
-      # grep for brakeman version
+  if [[ "$INPUT_BRAKEMAN_VERSION" == "gemfile" ]]; then
+    if [ -f "Gemfile.lock" ]; then
       BRAKEMAN_GEMFILE_VERSION=$(ruby -ne 'print $& if /^\s{4}brakeman\s\(\K.*(?=\))/' Gemfile.lock)
-
-      # if brakeman version found, then pass it to the gem install
-      # left it empty otherwise, so no version will be passed
       if [ -n "$BRAKEMAN_GEMFILE_VERSION" ]; then
         BRAKEMAN_VERSION=$BRAKEMAN_GEMFILE_VERSION
-        else
-          printf "Cannot get the brakeman's version from Gemfile.lock. The latest version will be installed."
-      fi
       else
-        printf 'Gemfile.lock not found. The latest version will be installed.'
-    fi
+        echo "⚠️ Could not detect Brakeman version from Gemfile.lock. Installing latest."
+        BRAKEMAN_VERSION=""
+      fi
     else
-      # set desired brakeman version
-      BRAKEMAN_VERSION=$INPUT_BRAKEMAN_VERSION
+      echo "⚠️ Gemfile.lock not found. Installing latest Brakeman."
+      BRAKEMAN_VERSION=""
+    fi
+  else
+    BRAKEMAN_VERSION="$INPUT_BRAKEMAN_VERSION"
   fi
 
-  gem install -N brakeman --version "${BRAKEMAN_VERSION}"
-  echo '::endgroup::'
+  gem install -N brakeman --version "$BRAKEMAN_VERSION"
+
+  echo "::endgroup::"
 fi
 
-if [ "${INPUT_USE_BUNDLER}" = "false" ]; then
-  BUNDLE_EXEC=""
+# Setup bundler exec if needed
+if [[ "$INPUT_USE_BUNDLER" == "true" ]]; then
+  export BUNDLE_EXEC="bundle exec "
 else
-  BUNDLE_EXEC="bundle exec "
+  export BUNDLE_EXEC=""
 fi
 
-echo '::group:: Running brakeman with reviewdog 🐶 ...'
-BRAKEMAN_REPORT_FILE="$TEMP_PATH"/brakeman_report
+# Run mode-specific logic
+if [[ "$INPUT_MODE" == "diff" ]]; then
+  ruby "$GITHUB_ACTION_PATH/run_diff.rb" "$MERGE_BASE_REF" "$MERGE_BASE_SHA" "$CHANGED_RUBY_FILES"
+else
+  echo "::group::🐶 Installing reviewdog ..."
+  curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+    | sh -s -- -b "$TEMP_PATH" "$REVIEWDOG_VERSION"
+  echo "::endgroup::"
 
-# shellcheck disable=SC2086
-${BUNDLE_EXEC}brakeman --quiet --format tabs --no-exit-on-warn --no-exit-on-error ${INPUT_BRAKEMAN_FLAGS} --output "$BRAKEMAN_REPORT_FILE"
-reviewdog < "$BRAKEMAN_REPORT_FILE" \
-  -f=brakeman \
-  -name="${INPUT_TOOL_NAME}" \
-  -reporter="${INPUT_REPORTER}" \
-  -filter-mode="${INPUT_FILTER_MODE}" \
-  -fail-level="${INPUT_FAIL_LEVEL}" \
-  -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
-  -level="${INPUT_LEVEL}" \
-  "${INPUT_REVIEWDOG_FLAGS}"
-
-exit_code=$?
-echo '::endgroup::'
-
-exit $exit_code
+  bash "$GITHUB_ACTION_PATH/run_full.sh"
+fi


### PR DESCRIPTION
## You can now choose between 2 modes:
1. `full` (default) - how this action used to work up until now. Uses `reviewdog` to comment on the pull request for every warning raised by brakeman.
2. `diff` - compares Brakeman warnings between the base and current commit and **fails the pipeline only if new warnings were introduced in the changed Ruby files**. Useful for enforcing incremental security improvements without blocking unrelated PRs.

## Examples
### `MODE: "full"`
- [Success](https://github.com/BioData/customer_portal/actions/runs/15737766876/job/44354975676?pr=33)
- [Failure](https://github.com/BioData/customer_portal/actions/runs/15612180338/job/44352650413?pr=33)
### `MODE: "diff"`
- [Success](https://github.com/BioData/Labguru/actions/runs/15737731969/job/44355451357)
- [Failure](https://github.com/BioData/Labguru/actions/runs/15665329709/job/44352658283?pr=8267)

